### PR TITLE
delay loading of the properties for the property condition

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PokemonPropertiesLootCondition.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PokemonPropertiesLootCondition.kt
@@ -11,7 +11,7 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 
 class PokemonPropertiesLootCondition(
-    val properties: PokemonProperties,
+    val properties: String,
 ) : LootItemCondition {
     companion object {
         object KEYS {
@@ -20,13 +20,14 @@ class PokemonPropertiesLootCondition(
 
         val CODEC: MapCodec<PokemonPropertiesLootCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
-                Codec.STRING.fieldOf(KEYS.PROPERTIES).forGetter { it.properties.originalString }
-            ).apply(instance) { PokemonPropertiesLootCondition(it.toProperties()) }
+                Codec.STRING.fieldOf(KEYS.PROPERTIES).forGetter { it.properties }
+            ).apply(instance) { PokemonPropertiesLootCondition(it) }
         }
     }
 
     override fun test(context: LootContext): Boolean {
         val pokemon: Pokemon = context.getParam(LootConditions.PARAMS.POKEMON_DETAILS)!!
+        val properties: PokemonProperties = PokemonProperties.parse(properties)
         return properties.matches(pokemon)
     }
 


### PR DESCRIPTION
There was an issue where, when loading the game server for the first time, the PokemonProperties wouldn't compare properly. I imagine this is because some Cobblemon data didn't have the chance to load before the condition started using PokemonProperties, causing the created property to ignore the missing bits.
Rainbow wooloo apocalypse avoided.
