### PR TITLE
added/refactored out evolution dropper

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
@@ -5,6 +5,7 @@ import net.minecraft.resources.ResourceLocation
 import us.timinc.mc.cobblemon.droploottables.config.ConfigBuilder
 import us.timinc.mc.cobblemon.droploottables.config.MainConfig
 import us.timinc.mc.cobblemon.droploottables.droppers.Droppers
+import us.timinc.mc.cobblemon.droploottables.events.DropLootTablesEventHandlers
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
 import us.timinc.mc.cobblemon.droploottables.lootconditions.counter.CounterLootConditions
 
@@ -17,6 +18,7 @@ object DropLootTables : ModInitializer {
         config = ConfigBuilder.load(MainConfig::class.java, MOD_ID)
         LootConditions.register()
         Droppers.load()
+        DropLootTablesEventHandlers.register()
     }
 
     fun initializeCounter() {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
@@ -2,4 +2,5 @@ package us.timinc.mc.cobblemon.droploottables.config
 
 class MainConfig {
     var debug: Boolean = false
+    var useCobblemonDropsIfOverrideNotPresent = true
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/CaptureDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/CaptureDropper.kt
@@ -21,7 +21,7 @@ object CaptureDropper : AbstractFormDropper("capture") {
                     LootContextParams.ORIGIN to dropperEntity.position(),
                     LootContextParams.THIS_ENTITY to dropperEntity,
                     LootConditions.PARAMS.POKEMON_DETAILS to event.pokemon,
-                    LootContextParams.DIRECT_ATTACKING_ENTITY to event.player
+                    LootContextParams.ATTACKING_ENTITY to event.player
                 ),
                 mapOf(),
                 event.player.luck

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/Droppers.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/Droppers.kt
@@ -6,5 +6,6 @@ object Droppers {
         KoDropper.load()
         ReleaseDropper.load()
         FossilRevivedDropper.load()
+        EvolutionDropper.load()
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
@@ -1,10 +1,15 @@
 package us.timinc.mc.cobblemon.droploottables.droppers
 
 import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.api.drop.ItemDropEntry
 import com.cobblemon.mod.common.api.events.CobblemonEvents
+import net.minecraft.core.registries.Registries
 import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.debug
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
@@ -18,6 +23,7 @@ object EvolutionDropper : AbstractFormDropper("evolve") {
             val level = positionalEntity.level()
             if (level !is ServerLevel) return@subscribe
             val position = positionalEntity.position()
+            val form = event.pokemon.form
 
             val lootParams = LootParams(
                 level,
@@ -30,12 +36,30 @@ object EvolutionDropper : AbstractFormDropper("evolve") {
                 mapOf(),
                 player.luck
             )
-            val drops = getDrops(
+            val finalDrops: MutableList<ItemStack> = mutableListOf()
+            val tableDrops = getDrops(
                 lootParams,
-                FormDropContext(event.pokemon.form)
+                FormDropContext(form)
             )
+            finalDrops.addAll(tableDrops)
 
-            giveDropsToPlayer(drops, player)
+            if (!lootTableExists(level, getFormDropId(form)) && config.useCobblemonDropsIfOverrideNotPresent) {
+                val cobbleDrops = event.evolution.drops.getDrops(pokemon = event.pokemon)
+                finalDrops.addAll(cobbleDrops.mapNotNull { drop ->
+                    if (drop is ItemDropEntry) {
+                        val item = level.registryAccess().registryOrThrow(Registries.ITEM).get(drop.item)
+                        if (item === null) {
+                            debug("Unable to drop item ${drop.item}")
+                            return@mapNotNull null
+                        }
+                        return@mapNotNull ItemStack(item, drop.quantityRange?.random() ?: drop.quantity)
+                    }
+                    drop.drop(null, level, position, player)
+                    return@mapNotNull null
+                })
+            }
+
+            giveDropsToPlayer(finalDrops, player)
         }
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
@@ -3,26 +3,21 @@ package us.timinc.mc.cobblemon.droploottables.droppers
 import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.events.CobblemonEvents
 import net.minecraft.server.level.ServerLevel
-import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
 
-object KoDropper : AbstractFormDropper("ko") {
+object EvolutionDropper : AbstractFormDropper("evolve") {
     override fun load() {
-        CobblemonEvents.POKEMON_FAINTED.subscribe(Priority.LOWEST) { event ->
+        CobblemonEvents.EVOLUTION_COMPLETE.subscribe(Priority.LOWEST) { event ->
             val dropperEntity = event.pokemon.entity
             val player = event.pokemon.getOwnerPlayer() ?: return@subscribe
             val positionalEntity = dropperEntity ?: player
             val level = positionalEntity.level()
             if (level !is ServerLevel) return@subscribe
             val position = positionalEntity.position()
-            val wasInBattle = dropperEntity?.isBattling ?: false
-            val attacker = dropperEntity?.lastAttacker
-            val directAttackingEntity = dropperEntity?.lastDamageSource
-            val attackingPlayer = if (attacker is ServerPlayer) attacker else null
 
             val lootParams = LootParams(
                 level,
@@ -30,10 +25,7 @@ object KoDropper : AbstractFormDropper("ko") {
                     LootContextParams.ORIGIN to position,
                     LootContextParams.THIS_ENTITY to dropperEntity,
                     LootConditions.PARAMS.POKEMON_DETAILS to event.pokemon,
-                    LootConditions.PARAMS.WAS_IN_BATTLE to wasInBattle,
-                    LootContextParams.ATTACKING_ENTITY to attacker,
-                    LootContextParams.DIRECT_ATTACKING_ENTITY to directAttackingEntity,
-                    LootContextParams.LAST_DAMAGE_PLAYER to attackingPlayer
+                    LootConditions.PARAMS.EVOLUTION to event.evolution
                 ),
                 mapOf(),
                 player.luck

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
@@ -1,13 +1,19 @@
 package us.timinc.mc.cobblemon.droploottables.droppers
 
 import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.api.drop.ItemDropEntry
 import com.cobblemon.mod.common.api.events.CobblemonEvents
-import com.cobblemon.mod.common.util.giveOrDropItemStack
+import net.minecraft.core.registries.Registries
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.item.ItemEntity
+import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
+import net.minecraft.world.phys.Vec3
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.debug
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
@@ -26,6 +32,7 @@ object KoDropper : AbstractFormDropper("ko") {
             val attacker = dropperEntity.lastAttacker
             val directAttackingEntity = dropperEntity.lastDamageSource
             val attackingPlayer = if (attacker is ServerPlayer) attacker else null
+            val form = event.pokemon.form
 
             val lootParams = LootParams(
                 level,
@@ -41,12 +48,30 @@ object KoDropper : AbstractFormDropper("ko") {
                 mapOf(),
                 player?.luck ?: 0F
             )
-            val drops = getDrops(
+            val finalDrops: MutableList<ItemStack> = mutableListOf()
+            val tableDrops = getDrops(
                 lootParams,
-                FormDropContext(event.pokemon.form)
+                FormDropContext(form)
             )
+            finalDrops.addAll(tableDrops)
 
-            player?.let { giveDropsToPlayer(drops, it) } ?: drops.forEach { drop ->
+            if (!lootTableExists(level, getFormDropId(form)) && config.useCobblemonDropsIfOverrideNotPresent) {
+                val cobbleDrops = form.drops.getDrops(pokemon = event.pokemon)
+                finalDrops.addAll(cobbleDrops.mapNotNull { drop ->
+                    if (drop is ItemDropEntry) {
+                        val item = level.registryAccess().registryOrThrow(Registries.ITEM).get(drop.item)
+                        if (item === null) {
+                            debug("Unable to drop item ${drop.item}")
+                            return@mapNotNull null
+                        }
+                        return@mapNotNull ItemStack(item, drop.quantityRange?.random() ?: drop.quantity)
+                    }
+                    drop.drop(null, level, position, player)
+                    return@mapNotNull null
+                })
+            }
+
+            player?.let { giveDropsToPlayer(finalDrops, it) } ?: finalDrops.forEach { drop ->
                 level.addFreshEntity(ItemEntity(level, dropperEntity.x, dropperEntity.y, dropperEntity.z, drop))
             }
         }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEventHandlers.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEventHandlers.kt
@@ -1,0 +1,10 @@
+package us.timinc.mc.cobblemon.droploottables.events
+
+import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.api.events.CobblemonEvents
+
+object DropLootTablesEventHandlers {
+    fun register() {
+        CobblemonEvents.LOOT_DROPPED.subscribe(Priority.HIGHEST) { it.cancel() }
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
@@ -1,5 +1,6 @@
 package us.timinc.mc.cobblemon.droploottables.lootconditions
 
+import com.cobblemon.mod.common.api.pokemon.evolution.Evolution
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.core.Registry
 import net.minecraft.core.registries.BuiltInRegistries
@@ -16,10 +17,9 @@ object LootConditions {
     val EGG_GROUP: LootItemConditionType = LootItemConditionType(EggGroupCondition.CODEC)
 
     object PARAMS {
-        val POKEMON_DETAILS: LootContextParam<Pokemon> =
-            LootContextParam(DropLootTables.modIdentifier("pokemon"))
-        val WAS_IN_BATTLE: LootContextParam<Boolean> =
-            LootContextParam(DropLootTables.modIdentifier("was_in_battle"))
+        val EVOLUTION: LootContextParam<Evolution> = LootContextParam(DropLootTables.modIdentifier("evolution"))
+        val POKEMON_DETAILS: LootContextParam<Pokemon> = LootContextParam(DropLootTables.modIdentifier("pokemon"))
+        val WAS_IN_BATTLE: LootContextParam<Boolean> = LootContextParam(DropLootTables.modIdentifier("was_in_battle"))
     }
 
     fun register() {


### PR DESCRIPTION
separated out the KO dropper, which was using the LOOT_DROP event, from the evolution dropper, as evolution drops were also triggering the LOOT_DROP event. this made evolutions fire as though they were KO drops in this mod.
* cancelled original Cobblemon LOOT_DROPPED event
* switched KO dropper from LOOT_DROP event to POKEMON_FAINTED w/a wild check
* added evolution dropper