### PR TITLE
v1.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.1.0
+mod_version=1.6-fabric-1.2.0
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=droploottables
 

--- a/src/main/java/us/timinc/mc/cobblemon/droploottables/mixins/cobblemon/PokemonEntityMixin.java
+++ b/src/main/java/us/timinc/mc/cobblemon/droploottables/mixins/cobblemon/PokemonEntityMixin.java
@@ -1,0 +1,10 @@
+package us.timinc.mc.cobblemon.droploottables.mixins.cobblemon;
+
+@org.spongepowered.asm.mixin.Mixin(com.cobblemon.mod.common.entity.pokemon.PokemonEntity.class)
+public class PokemonEntityMixin {
+    @org.spongepowered.asm.mixin.injection.Inject(method = "tick", at = @org.spongepowered.asm.mixin.injection.At("HEAD"))
+    void onPokemonEntityTick(org.spongepowered.asm.mixin.injection.callback.CallbackInfo ci) {
+        com.cobblemon.mod.common.entity.pokemon.PokemonEntity me = (com.cobblemon.mod.common.entity.pokemon.PokemonEntity) ((Object) this);
+        us.timinc.mc.cobblemon.droploottables.DropLootTables.INSTANCE.pokemonEntityTicked(me);
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
@@ -5,6 +5,7 @@ import net.minecraft.resources.ResourceLocation
 import us.timinc.mc.cobblemon.droploottables.config.ConfigBuilder
 import us.timinc.mc.cobblemon.droploottables.config.MainConfig
 import us.timinc.mc.cobblemon.droploottables.droppers.Droppers
+import us.timinc.mc.cobblemon.droploottables.events.DropLootTablesEventHandlers
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
 import us.timinc.mc.cobblemon.droploottables.lootconditions.counter.CounterLootConditions
 
@@ -17,6 +18,7 @@ object DropLootTables : ModInitializer {
         config = ConfigBuilder.load(MainConfig::class.java, MOD_ID)
         LootConditions.register()
         Droppers.load()
+        DropLootTablesEventHandlers.register()
     }
 
     fun initializeCounter() {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/DropLootTables.kt
@@ -1,11 +1,14 @@
 package us.timinc.mc.cobblemon.droploottables
 
+import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
 import net.fabricmc.api.ModInitializer
 import net.minecraft.resources.ResourceLocation
 import us.timinc.mc.cobblemon.droploottables.config.ConfigBuilder
 import us.timinc.mc.cobblemon.droploottables.config.MainConfig
 import us.timinc.mc.cobblemon.droploottables.droppers.Droppers
 import us.timinc.mc.cobblemon.droploottables.events.DropLootTablesEventHandlers
+import us.timinc.mc.cobblemon.droploottables.events.DropLootTablesEvents
+import us.timinc.mc.cobblemon.droploottables.events.PokemonEntityTickedEvent
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
 import us.timinc.mc.cobblemon.droploottables.lootconditions.counter.CounterLootConditions
 
@@ -34,5 +37,9 @@ object DropLootTables : ModInitializer {
             return
         }
         println(msg)
+    }
+
+    fun pokemonEntityTicked(entity: PokemonEntity) {
+        DropLootTablesEvents.POKEMON_TICKED.post(PokemonEntityTickedEvent(entity))
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
@@ -16,4 +16,5 @@ fun toIntRange(str: String): IntRange {
 // This is here because the idea of an NPC owning a Pokemon isn't really well known yet. RCT in particular is causing
 // pokemon::isWild to return true even though it has an NPC trainer. So, double-check for the OT; wilds should never
 // have OTs is hopefully a sound idea.
-fun isActuallyWild(pokemon: Pokemon): Boolean = pokemon.isWild() && pokemon.originalTrainerType == OriginalTrainerType.NONE
+fun isActuallyWild(pokemon: Pokemon): Boolean =
+    pokemon.isWild() && pokemon.originalTrainerType == OriginalTrainerType.NONE

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
@@ -1,5 +1,8 @@
 package us.timinc.mc.cobblemon.droploottables
 
+import com.cobblemon.mod.common.pokemon.OriginalTrainerType
+import com.cobblemon.mod.common.pokemon.Pokemon
+
 fun toIntRange(str: String): IntRange {
     val (start, end) = str.split("..")
 
@@ -9,3 +12,8 @@ fun toIntRange(str: String): IntRange {
         throw IllegalArgumentException("'$start' and/or '$end' is/are not integers", e)
     }
 }
+
+// This is here because the idea of an NPC owning a Pokemon isn't really well known yet. RCT in particular is causing
+// pokemon::isWild to return true even though it has an NPC trainer. So, double-check for the OT; wilds should never
+// have OTs is hopefully a sound idea.
+fun isActuallyWild(pokemon: Pokemon): Boolean = pokemon.isWild() && pokemon.originalTrainerType == OriginalTrainerType.NONE

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/Util.kt
@@ -2,6 +2,7 @@ package us.timinc.mc.cobblemon.droploottables
 
 import com.cobblemon.mod.common.pokemon.OriginalTrainerType
 import com.cobblemon.mod.common.pokemon.Pokemon
+import com.cobblemon.mod.common.util.math.FloatRange
 
 fun toIntRange(str: String): IntRange {
     val (start, end) = str.split("..")
@@ -10,6 +11,16 @@ fun toIntRange(str: String): IntRange {
         start.toInt()..end.toInt()
     } catch (e: NumberFormatException) {
         throw IllegalArgumentException("'$start' and/or '$end' is/are not integers", e)
+    }
+}
+
+fun toFloatRange(str: String): FloatRange {
+    val (start, end) = str.split("..")
+
+    return try {
+        FloatRange(start.toFloat(), end.toFloat())
+    } catch (e: NumberFormatException) {
+        throw IllegalArgumentException("'$start' and/or '$end' is/are not Floats", e)
     }
 }
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
@@ -1,6 +1,14 @@
 package us.timinc.mc.cobblemon.droploottables.config
 
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties
+import com.cobblemon.mod.common.pokemon.Pokemon
+import us.timinc.mc.cobblemon.droploottables.toIntRange
+
 class MainConfig {
     var debug: Boolean = false
     var useCobblemonDropsIfOverrideNotPresent = true
+    var granularDropPeriods: Map<String, String> = mapOf()
+
+    fun getGranularDropPeriodFor(pokemon: Pokemon): IntRange? =
+        granularDropPeriods.entries.find { (k) -> PokemonProperties.parse(k).matches(pokemon) }?.value?.let(::toIntRange)
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
@@ -10,5 +10,7 @@ class MainConfig {
     var granularDropPeriods: Map<String, String> = mapOf()
 
     fun getGranularDropPeriodFor(pokemon: Pokemon): IntRange? =
-        granularDropPeriods.entries.find { (k) -> PokemonProperties.parse(k).matches(pokemon) }?.value?.let(::toIntRange)
+        granularDropPeriods.entries.find { (k) ->
+            PokemonProperties.parse(k).matches(pokemon)
+        }?.value?.let(::toIntRange)
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/config/MainConfig.kt
@@ -2,4 +2,5 @@ package us.timinc.mc.cobblemon.droploottables.config
 
 class MainConfig {
     var debug: Boolean = false
+    var useCobblemonDropsIfOverrideNotPresent = true
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/CaptureDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/CaptureDropper.kt
@@ -21,7 +21,7 @@ object CaptureDropper : AbstractFormDropper("capture") {
                     LootContextParams.ORIGIN to dropperEntity.position(),
                     LootContextParams.THIS_ENTITY to dropperEntity,
                     LootConditions.PARAMS.POKEMON_DETAILS to event.pokemon,
-                    LootContextParams.DIRECT_ATTACKING_ENTITY to event.player
+                    LootContextParams.ATTACKING_ENTITY to event.player
                 ),
                 mapOf(),
                 event.player.luck

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/Droppers.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/Droppers.kt
@@ -7,5 +7,6 @@ object Droppers {
         ReleaseDropper.load()
         FossilRevivedDropper.load()
         EvolutionDropper.load()
+        PeriodicDropper.load()
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/Droppers.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/Droppers.kt
@@ -6,5 +6,6 @@ object Droppers {
         KoDropper.load()
         ReleaseDropper.load()
         FossilRevivedDropper.load()
+        EvolutionDropper.load()
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
@@ -1,10 +1,15 @@
 package us.timinc.mc.cobblemon.droploottables.droppers
 
 import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.api.drop.ItemDropEntry
 import com.cobblemon.mod.common.api.events.CobblemonEvents
+import net.minecraft.core.registries.Registries
 import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.debug
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
@@ -18,6 +23,7 @@ object EvolutionDropper : AbstractFormDropper("evolve") {
             val level = positionalEntity.level()
             if (level !is ServerLevel) return@subscribe
             val position = positionalEntity.position()
+            val form = event.pokemon.form
 
             val lootParams = LootParams(
                 level,
@@ -30,12 +36,30 @@ object EvolutionDropper : AbstractFormDropper("evolve") {
                 mapOf(),
                 player.luck
             )
-            val drops = getDrops(
+            val finalDrops: MutableList<ItemStack> = mutableListOf()
+            val tableDrops = getDrops(
                 lootParams,
-                FormDropContext(event.pokemon.form)
+                FormDropContext(form)
             )
+            finalDrops.addAll(tableDrops)
 
-            giveDropsToPlayer(drops, player)
+            if (!lootTableExists(level, getFormDropId(form)) && config.useCobblemonDropsIfOverrideNotPresent) {
+                val cobbleDrops = event.evolution.drops.getDrops(pokemon = event.pokemon)
+                finalDrops.addAll(cobbleDrops.mapNotNull { drop ->
+                    if (drop is ItemDropEntry) {
+                        val item = level.registryAccess().registryOrThrow(Registries.ITEM).get(drop.item)
+                        if (item === null) {
+                            debug("Unable to drop item ${drop.item}")
+                            return@mapNotNull null
+                        }
+                        return@mapNotNull ItemStack(item, drop.quantityRange?.random() ?: drop.quantity)
+                    }
+                    drop.drop(null, level, position, player)
+                    return@mapNotNull null
+                })
+            }
+
+            giveDropsToPlayer(finalDrops, player)
         }
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/EvolutionDropper.kt
@@ -3,26 +3,21 @@ package us.timinc.mc.cobblemon.droploottables.droppers
 import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.events.CobblemonEvents
 import net.minecraft.server.level.ServerLevel
-import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
 
-object KoDropper : AbstractFormDropper("ko") {
+object EvolutionDropper : AbstractFormDropper("evolve") {
     override fun load() {
-        CobblemonEvents.POKEMON_FAINTED.subscribe(Priority.LOWEST) { event ->
+        CobblemonEvents.EVOLUTION_COMPLETE.subscribe(Priority.LOWEST) { event ->
             val dropperEntity = event.pokemon.entity
             val player = event.pokemon.getOwnerPlayer() ?: return@subscribe
             val positionalEntity = dropperEntity ?: player
             val level = positionalEntity.level()
             if (level !is ServerLevel) return@subscribe
             val position = positionalEntity.position()
-            val wasInBattle = dropperEntity?.isBattling ?: false
-            val attacker = dropperEntity?.lastAttacker
-            val directAttackingEntity = dropperEntity?.lastDamageSource
-            val attackingPlayer = if (attacker is ServerPlayer) attacker else null
 
             val lootParams = LootParams(
                 level,
@@ -30,10 +25,7 @@ object KoDropper : AbstractFormDropper("ko") {
                     LootContextParams.ORIGIN to position,
                     LootContextParams.THIS_ENTITY to dropperEntity,
                     LootConditions.PARAMS.POKEMON_DETAILS to event.pokemon,
-                    LootConditions.PARAMS.WAS_IN_BATTLE to wasInBattle,
-                    LootContextParams.ATTACKING_ENTITY to attacker,
-                    LootContextParams.DIRECT_ATTACKING_ENTITY to directAttackingEntity,
-                    LootContextParams.LAST_DAMAGE_PLAYER to attackingPlayer
+                    LootConditions.PARAMS.EVOLUTION to event.evolution
                 ),
                 mapOf(),
                 player.luck

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
@@ -2,7 +2,6 @@ package us.timinc.mc.cobblemon.droploottables.droppers
 
 import com.cobblemon.mod.common.api.Priority
 import com.cobblemon.mod.common.api.drop.ItemDropEntry
-import com.cobblemon.mod.common.api.events.CobblemonEvents
 import net.minecraft.core.registries.Registries
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
@@ -10,8 +9,6 @@ import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
-import net.minecraft.world.phys.Vec3
-import us.timinc.mc.cobblemon.droploottables.DropLootTables
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.debug
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
@@ -1,13 +1,19 @@
 package us.timinc.mc.cobblemon.droploottables.droppers
 
 import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.api.drop.ItemDropEntry
 import com.cobblemon.mod.common.api.events.CobblemonEvents
-import com.cobblemon.mod.common.util.giveOrDropItemStack
+import net.minecraft.core.registries.Registries
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.item.ItemEntity
+import net.minecraft.world.item.ItemStack
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
+import net.minecraft.world.phys.Vec3
+import us.timinc.mc.cobblemon.droploottables.DropLootTables
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.debug
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
@@ -26,6 +32,7 @@ object KoDropper : AbstractFormDropper("ko") {
             val attacker = dropperEntity.lastAttacker
             val directAttackingEntity = dropperEntity.lastDamageSource
             val attackingPlayer = if (attacker is ServerPlayer) attacker else null
+            val form = event.pokemon.form
 
             val lootParams = LootParams(
                 level,
@@ -41,12 +48,30 @@ object KoDropper : AbstractFormDropper("ko") {
                 mapOf(),
                 player?.luck ?: 0F
             )
-            val drops = getDrops(
+            val finalDrops: MutableList<ItemStack> = mutableListOf()
+            val tableDrops = getDrops(
                 lootParams,
-                FormDropContext(event.pokemon.form)
+                FormDropContext(form)
             )
+            finalDrops.addAll(tableDrops)
 
-            player?.let { giveDropsToPlayer(drops, it) } ?: drops.forEach { drop ->
+            if (!lootTableExists(level, getFormDropId(form)) && config.useCobblemonDropsIfOverrideNotPresent) {
+                val cobbleDrops = form.drops.getDrops(pokemon = event.pokemon)
+                finalDrops.addAll(cobbleDrops.mapNotNull { drop ->
+                    if (drop is ItemDropEntry) {
+                        val item = level.registryAccess().registryOrThrow(Registries.ITEM).get(drop.item)
+                        if (item === null) {
+                            debug("Unable to drop item ${drop.item}")
+                            return@mapNotNull null
+                        }
+                        return@mapNotNull ItemStack(item, drop.quantityRange?.random() ?: drop.quantity)
+                    }
+                    drop.drop(null, level, position, player)
+                    return@mapNotNull null
+                })
+            }
+
+            player?.let { giveDropsToPlayer(finalDrops, it) } ?: finalDrops.forEach { drop ->
                 level.addFreshEntity(ItemEntity(level, dropperEntity.x, dropperEntity.y, dropperEntity.z, drop))
             }
         }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
@@ -16,13 +16,12 @@ import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.debug
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
+import us.timinc.mc.cobblemon.droploottables.events.DropLootTablesEvents
 import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
 
 object KoDropper : AbstractFormDropper("ko") {
     override fun load() {
-        CobblemonEvents.POKEMON_FAINTED.subscribe(Priority.LOWEST) { event ->
-            if (!event.pokemon.isWild()) return@subscribe
-
+        DropLootTablesEvents.WILD_POKEMON_FAINTED.subscribe(Priority.LOWEST) { event ->
             val dropperEntity = event.pokemon.entity ?: return@subscribe
             val player = dropperEntity.killer
             val level = dropperEntity.level()

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/PeriodicDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/PeriodicDropper.kt
@@ -1,0 +1,70 @@
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package us.timinc.mc.cobblemon.droploottables.droppers
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.entity.item.ItemEntity
+import net.minecraft.world.level.storage.loot.LootParams
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
+import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
+import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
+import us.timinc.mc.cobblemon.droploottables.events.DropLootTablesEvents
+import us.timinc.mc.cobblemon.droploottables.lootconditions.LootConditions
+
+object PeriodicDropper : AbstractFormDropper("periodic") {
+    const val PERSISTENT_DATA_KEY_TIMER = "droploottables:periodic_timer"
+
+    override fun load() {
+        DropLootTablesEvents.POKEMON_TICKED.subscribe { event ->
+            val dropperEntity = event.entity
+            val pokemon = dropperEntity.pokemon
+            val player = pokemon.getOwnerPlayer()
+            val level = dropperEntity.level()
+            if (level !is ServerLevel) return@subscribe
+            if (!isReady(pokemon)) return@subscribe
+            val position = dropperEntity.position()
+            val form = pokemon.form
+
+            val lootParams = LootParams(
+                level,
+                mapOf(
+                    LootContextParams.ORIGIN to position,
+                    LootContextParams.THIS_ENTITY to dropperEntity,
+                    LootConditions.PARAMS.POKEMON_DETAILS to pokemon
+                ),
+                mapOf(),
+                player?.luck ?: 0F
+            )
+            val drops = getDrops(
+                lootParams,
+                FormDropContext(form)
+            )
+
+            drops.forEach { drop ->
+                level.addFreshEntity(ItemEntity(level, dropperEntity.x, dropperEntity.y, dropperEntity.z, drop))
+            }
+        }
+    }
+
+    private fun getDropTimer(pokemon: Pokemon): Int {
+        val range = config.getGranularDropPeriodFor(pokemon) ?: IntRange(6000, 12000)
+        println("Got range $range from ${pokemon.species}")
+        return range.random()
+    }
+
+    private fun isReady(pokemon: Pokemon): Boolean {
+        if (!pokemon.persistentData.contains(PERSISTENT_DATA_KEY_TIMER)) {
+            pokemon.persistentData.putInt(PERSISTENT_DATA_KEY_TIMER, getDropTimer(pokemon))
+            return false
+        }
+        val currentValue = pokemon.persistentData.getInt(PERSISTENT_DATA_KEY_TIMER)
+        if (currentValue <= 0) {
+            pokemon.persistentData.putInt(PERSISTENT_DATA_KEY_TIMER, getDropTimer(pokemon))
+            return true
+        }
+        pokemon.persistentData.putInt(PERSISTENT_DATA_KEY_TIMER, currentValue - 1)
+        return false
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/PeriodicDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/PeriodicDropper.kt
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.item.ItemEntity
 import net.minecraft.world.level.storage.loot.LootParams
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams
 import us.timinc.mc.cobblemon.droploottables.DropLootTables.config
+import us.timinc.mc.cobblemon.droploottables.DropLootTables.debug
 import us.timinc.mc.cobblemon.droploottables.api.droppers.AbstractFormDropper
 import us.timinc.mc.cobblemon.droploottables.api.droppers.FormDropContext
 import us.timinc.mc.cobblemon.droploottables.events.DropLootTablesEvents
@@ -50,7 +51,7 @@ object PeriodicDropper : AbstractFormDropper("periodic") {
 
     private fun getDropTimer(pokemon: Pokemon): Int {
         val range = config.getGranularDropPeriodFor(pokemon) ?: IntRange(6000, 12000)
-        println("Got range $range from ${pokemon.species}")
+        debug("Got range $range from ${pokemon.species}")
         return range.random()
     }
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEventHandlers.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEventHandlers.kt
@@ -1,0 +1,10 @@
+package us.timinc.mc.cobblemon.droploottables.events
+
+import com.cobblemon.mod.common.api.Priority
+import com.cobblemon.mod.common.api.events.CobblemonEvents
+
+object DropLootTablesEventHandlers {
+    fun register() {
+        CobblemonEvents.LOOT_DROPPED.subscribe(Priority.HIGHEST) { it.cancel() }
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEvents.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEvents.kt
@@ -1,0 +1,22 @@
+package us.timinc.mc.cobblemon.droploottables.events
+
+import com.cobblemon.mod.common.api.events.CobblemonEvents
+import com.cobblemon.mod.common.api.reactive.EventObservable
+import com.cobblemon.mod.common.api.reactive.Observable.Companion.filter
+
+object DropLootTablesEvents {
+    @JvmField
+    val POKEMON_TICKED = EventObservable<PokemonEntityTickedEvent>()
+
+    @JvmField
+    val WILD_POKEMON_TICKED = POKEMON_TICKED
+        .pipe(
+            filter { it.entity.pokemon.isWild() }
+        )
+
+    @JvmField
+    val WILD_POKEMON_FAINTED = CobblemonEvents.POKEMON_FAINTED
+        .pipe(
+            filter { it.pokemon.isWild() }
+        )
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEvents.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/DropLootTablesEvents.kt
@@ -3,6 +3,7 @@ package us.timinc.mc.cobblemon.droploottables.events
 import com.cobblemon.mod.common.api.events.CobblemonEvents
 import com.cobblemon.mod.common.api.reactive.EventObservable
 import com.cobblemon.mod.common.api.reactive.Observable.Companion.filter
+import us.timinc.mc.cobblemon.droploottables.isActuallyWild
 
 object DropLootTablesEvents {
     @JvmField
@@ -11,12 +12,12 @@ object DropLootTablesEvents {
     @JvmField
     val WILD_POKEMON_TICKED = POKEMON_TICKED
         .pipe(
-            filter { it.entity.pokemon.isWild() }
+            filter { isActuallyWild(it.entity.pokemon) }
         )
 
     @JvmField
     val WILD_POKEMON_FAINTED = CobblemonEvents.POKEMON_FAINTED
         .pipe(
-            filter { it.pokemon.isWild() }
+            filter { isActuallyWild(it.pokemon) }
         )
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/PokemonEntityTickedEvent.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/PokemonEntityTickedEvent.kt
@@ -1,0 +1,7 @@
+package us.timinc.mc.cobblemon.droploottables.events
+
+import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
+
+data class PokemonEntityTickedEvent(
+    val entity: PokemonEntity
+)

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/PokemonEntityTickedEvent.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/events/PokemonEntityTickedEvent.kt
@@ -3,5 +3,5 @@ package us.timinc.mc.cobblemon.droploottables.events
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
 
 data class PokemonEntityTickedEvent(
-    val entity: PokemonEntity
+    val entity: PokemonEntity,
 )

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/FriendshipLevelCondition.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/FriendshipLevelCondition.kt
@@ -1,0 +1,36 @@
+package us.timinc.mc.cobblemon.droploottables.lootconditions
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.toIntRange
+
+class FriendshipLevelCondition(
+    val range: IntRange,
+) : LootItemCondition {
+    companion object {
+        object KEYS {
+            const val RANGE = "range"
+        }
+
+        val CODEC: MapCodec<FriendshipLevelCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.fieldOf(KEYS.RANGE).forGetter { it.range.toString() }
+            ).apply(instance) { FriendshipLevelCondition(toIntRange(it)) }
+        }
+    }
+
+    override fun test(context: LootContext): Boolean {
+        val pokemon: Pokemon = context.getParam(LootConditions.PARAMS.POKEMON_DETAILS)!!
+        val pokemonFriendship = pokemon.friendship
+        return range.contains(pokemonFriendship)
+    }
+
+    override fun getType(): LootItemConditionType {
+        return LootConditions.POKEMON_FRIENDSHIP
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
@@ -9,6 +9,7 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables
 
 object LootConditions {
+    val POKEMON_FRIENDSHIP: LootItemConditionType = LootItemConditionType(FriendshipLevelCondition.CODEC)
     val POKEMON_PROPERTIES: LootItemConditionType = LootItemConditionType(PokemonPropertiesLootCondition.CODEC)
     val POKEMON_LEVEL: LootItemConditionType = LootItemConditionType(PokemonLevelLootCondition.CODEC)
     val POKEMON_TYPE: LootItemConditionType = LootItemConditionType(PokemonElementalTypeLootCondition.CODEC)
@@ -42,6 +43,9 @@ object LootConditions {
         )
         Registry.register(
             BuiltInRegistries.LOOT_CONDITION_TYPE, DropLootTables.modIdentifier("egg_group"), EGG_GROUP
+        )
+        Registry.register(
+            BuiltInRegistries.LOOT_CONDITION_TYPE, DropLootTables.modIdentifier("friendship"), POKEMON_FRIENDSHIP
         )
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
@@ -9,6 +9,7 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables
 
 object LootConditions {
+    val PERSISTENT_DATA: LootItemConditionType = LootItemConditionType(PersistentDataCondition.CODEC)
     val POKEMON_FRIENDSHIP: LootItemConditionType = LootItemConditionType(FriendshipLevelCondition.CODEC)
     val POKEMON_PROPERTIES: LootItemConditionType = LootItemConditionType(PokemonPropertiesLootCondition.CODEC)
     val POKEMON_LEVEL: LootItemConditionType = LootItemConditionType(PokemonLevelLootCondition.CODEC)
@@ -46,6 +47,9 @@ object LootConditions {
         )
         Registry.register(
             BuiltInRegistries.LOOT_CONDITION_TYPE, DropLootTables.modIdentifier("friendship"), POKEMON_FRIENDSHIP
+        )
+        Registry.register(
+            BuiltInRegistries.LOOT_CONDITION_TYPE, DropLootTables.modIdentifier("persistent_data"), PERSISTENT_DATA
         )
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
@@ -1,5 +1,6 @@
 package us.timinc.mc.cobblemon.droploottables.lootconditions
 
+import com.cobblemon.mod.common.api.pokemon.evolution.Evolution
 import com.cobblemon.mod.common.pokemon.Pokemon
 import net.minecraft.core.Registry
 import net.minecraft.core.registries.BuiltInRegistries
@@ -16,10 +17,9 @@ object LootConditions {
     val EGG_GROUP: LootItemConditionType = LootItemConditionType(EggGroupCondition.CODEC)
 
     object PARAMS {
-        val POKEMON_DETAILS: LootContextParam<Pokemon> =
-            LootContextParam(DropLootTables.modIdentifier("pokemon"))
-        val WAS_IN_BATTLE: LootContextParam<Boolean> =
-            LootContextParam(DropLootTables.modIdentifier("was_in_battle"))
+        val EVOLUTION: LootContextParam<Evolution> = LootContextParam(DropLootTables.modIdentifier("evolution"))
+        val POKEMON_DETAILS: LootContextParam<Pokemon> = LootContextParam(DropLootTables.modIdentifier("pokemon"))
+        val WAS_IN_BATTLE: LootContextParam<Boolean> = LootContextParam(DropLootTables.modIdentifier("was_in_battle"))
     }
 
     fun register() {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/LootConditions.kt
@@ -9,6 +9,7 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 import us.timinc.mc.cobblemon.droploottables.DropLootTables
 
 object LootConditions {
+    val PERSISTENT_DATA_RANGE: LootItemConditionType = LootItemConditionType(PersistentDataRangeCondition.CODEC)
     val PERSISTENT_DATA: LootItemConditionType = LootItemConditionType(PersistentDataCondition.CODEC)
     val POKEMON_FRIENDSHIP: LootItemConditionType = LootItemConditionType(FriendshipLevelCondition.CODEC)
     val POKEMON_PROPERTIES: LootItemConditionType = LootItemConditionType(PokemonPropertiesLootCondition.CODEC)
@@ -50,6 +51,9 @@ object LootConditions {
         )
         Registry.register(
             BuiltInRegistries.LOOT_CONDITION_TYPE, DropLootTables.modIdentifier("persistent_data"), PERSISTENT_DATA
+        )
+        Registry.register(
+            BuiltInRegistries.LOOT_CONDITION_TYPE, DropLootTables.modIdentifier("persistent_data_range"), PERSISTENT_DATA_RANGE
         )
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PersistentDataCondition.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PersistentDataCondition.kt
@@ -1,0 +1,36 @@
+package us.timinc.mc.cobblemon.droploottables.lootconditions
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+
+class PersistentDataCondition(
+    val key: String,
+    val value: String,
+) : LootItemCondition {
+    companion object {
+        object KEYS {
+            const val KEY = "key"
+            const val VALUE = "value"
+        }
+
+        val CODEC: MapCodec<PersistentDataCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.fieldOf(KEYS.KEY).forGetter(PersistentDataCondition::key),
+                Codec.STRING.fieldOf(KEYS.VALUE).forGetter(PersistentDataCondition::value)
+            ).apply(instance, ::PersistentDataCondition)
+        }
+    }
+
+    override fun test(context: LootContext): Boolean {
+        val pokemon: Pokemon = context.getParamOrNull(LootConditions.PARAMS.POKEMON_DETAILS) ?: return false
+        val tagValue = pokemon.persistentData.get(key)?.asString ?: return false
+        return tagValue == value
+    }
+
+    override fun getType(): LootItemConditionType = LootConditions.PERSISTENT_DATA
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PersistentDataRangeCondition.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PersistentDataRangeCondition.kt
@@ -1,0 +1,39 @@
+package us.timinc.mc.cobblemon.droploottables.lootconditions
+
+import com.cobblemon.mod.common.pokemon.Pokemon
+import com.cobblemon.mod.common.util.math.FloatRange
+import com.mojang.serialization.Codec
+import com.mojang.serialization.MapCodec
+import com.mojang.serialization.codecs.RecordCodecBuilder
+import net.minecraft.world.level.storage.loot.LootContext
+import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
+import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
+import us.timinc.mc.cobblemon.droploottables.toFloatRange
+
+class PersistentDataRangeCondition(
+    val key: String,
+    val range: FloatRange,
+) : LootItemCondition {
+    companion object {
+        object KEYS {
+            const val KEY = "key"
+            const val RANGE = "range"
+        }
+
+        val CODEC: MapCodec<PersistentDataRangeCondition> = RecordCodecBuilder.mapCodec { instance ->
+            instance.group(
+                Codec.STRING.fieldOf(KEYS.KEY).forGetter(PersistentDataRangeCondition::key),
+                Codec.STRING.fieldOf(KEYS.RANGE).forGetter { it.range.toString() }
+            ).apply(instance) { key, range -> PersistentDataRangeCondition(key, toFloatRange(range)) }
+        }
+    }
+
+    override fun test(context: LootContext): Boolean {
+        val pokemon: Pokemon = context.getParamOrNull(LootConditions.PARAMS.POKEMON_DETAILS) ?: return false
+        val tagStringValue = pokemon.persistentData.get(key)?.asString ?: return false
+        val tagValue = tagStringValue.toFloatOrNull() ?: return false
+        return range.contains(tagValue)
+    }
+
+    override fun getType(): LootItemConditionType = LootConditions.PERSISTENT_DATA_RANGE
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PokemonPropertiesLootCondition.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PokemonPropertiesLootCondition.kt
@@ -2,7 +2,6 @@ package us.timinc.mc.cobblemon.droploottables.lootconditions
 
 import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.pokemon.Pokemon
-import com.cobblemon.mod.common.util.toProperties
 import com.mojang.serialization.Codec
 import com.mojang.serialization.MapCodec
 import com.mojang.serialization.codecs.RecordCodecBuilder

--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PokemonPropertiesLootCondition.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/lootconditions/PokemonPropertiesLootCondition.kt
@@ -11,7 +11,7 @@ import net.minecraft.world.level.storage.loot.predicates.LootItemCondition
 import net.minecraft.world.level.storage.loot.predicates.LootItemConditionType
 
 class PokemonPropertiesLootCondition(
-    val properties: PokemonProperties,
+    val properties: String,
 ) : LootItemCondition {
     companion object {
         object KEYS {
@@ -20,13 +20,14 @@ class PokemonPropertiesLootCondition(
 
         val CODEC: MapCodec<PokemonPropertiesLootCondition> = RecordCodecBuilder.mapCodec { instance ->
             instance.group(
-                Codec.STRING.fieldOf(KEYS.PROPERTIES).forGetter { it.properties.originalString }
-            ).apply(instance) { PokemonPropertiesLootCondition(it.toProperties()) }
+                Codec.STRING.fieldOf(KEYS.PROPERTIES).forGetter { it.properties }
+            ).apply(instance) { PokemonPropertiesLootCondition(it) }
         }
     }
 
     override fun test(context: LootContext): Boolean {
         val pokemon: Pokemon = context.getParam(LootConditions.PARAMS.POKEMON_DETAILS)!!
+        val properties: PokemonProperties = PokemonProperties.parse(properties)
         return properties.matches(pokemon)
     }
 

--- a/src/main/resources/droploottables.mixins.json
+++ b/src/main/resources/droploottables.mixins.json
@@ -4,8 +4,8 @@
   "package": "us.timinc.mc.cobblemon.droploottables.mixins",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "counter.CounterPresent",
-    "cobblemon.PokemonEntityMixin"
+    "cobblemon.PokemonEntityMixin",
+    "counter.CounterPresent"
   ],
   "client": [],
   "server": []

--- a/src/main/resources/droploottables.mixins.json
+++ b/src/main/resources/droploottables.mixins.json
@@ -4,7 +4,8 @@
   "package": "us.timinc.mc.cobblemon.droploottables.mixins",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "counter.CounterPresent"
+    "counter.CounterPresent",
+    "cobblemon.PokemonEntityMixin"
   ],
   "client": [],
   "server": []

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "cobblemon_droploottables",
-  "version": "1.6-fabric-1.1.0",
+  "version": "1.6-fabric-1.2.0",
   "name": "Cobblemon Drop Loot Tables",
   "description": "Customize Pokémon loot drops using Minecraft's loot tables.",
   "authors": [


### PR DESCRIPTION
* fixed property condition loading too soon and ignoring bits and pieces of itself
* added an evolution dropper
* KO dropper now uses the POKEMON_FAINTED event instead of the LOOT_DROPPED event
* Cobblemon's LOOT_DROPPED event is now cancelled. I intend to introduce an event for this mod, but also broadcast a Cobblemon LOOT_DROPPED event of my own if I can, for maximum integration.
* added custom logic to drop Cobblemon drops according to species files, with config to turn that off. this includes the non-item drop types from Cobblemon.
* added a periodic wild dropper
* added a friendship condition
* fixed the wild check so it would work with mods like RCT, which still cause Cobblemon to think their NPCs team is wild
* added persistent data condition
* added persistent data range condition