### PR TITLE
prioritized vanilla drop table on entity

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/droploottables/droppers/KoDropper.kt
@@ -54,7 +54,8 @@ object KoDropper : AbstractFormDropper("ko") {
             finalDrops.addAll(tableDrops)
 
             if (!lootTableExists(level, getFormDropId(form)) && config.useCobblemonDropsIfOverrideNotPresent) {
-                val cobbleDrops = form.drops.getDrops(pokemon = event.pokemon)
+                val cobbleDropTable = event.pokemon.entity?.drops ?: event.pokemon.form.drops
+                val cobbleDrops = cobbleDropTable.getDrops(pokemon = event.pokemon)
                 finalDrops.addAll(cobbleDrops.mapNotNull { drop ->
                     if (drop is ItemDropEntry) {
                         val item = level.registryAccess().registryOrThrow(Registries.ITEM).get(drop.item)


### PR DESCRIPTION
fixes any spawns from vanilla Cobblemon with custom drops, like Gastly in the Nether, not being taken into account.
